### PR TITLE
only running observe on x64 runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup BuildObserver
-      if: inputs.observe
+      if: inputs.observe && runner.arch == 'X64'
       uses: crashappsec/buildobserver@nettrino/cplugin
 
     - name: Generate org-level access token


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context